### PR TITLE
feat: add CompactDialog component

### DIFF
--- a/src/components/CompactDialog/CompactDialog.tsx
+++ b/src/components/CompactDialog/CompactDialog.tsx
@@ -1,0 +1,84 @@
+import { Scrim } from '@equinor/eds-core-react';
+import React, { forwardRef, ReactNode, useCallback, useImperativeHandle, useState } from 'react';
+import CompactDialogCard from './CompactDialogCard';
+
+export interface CompactDialogProps {
+    children?: React.ReactNode | null;
+    /**
+     * Sets the dialog title
+     */
+    title?: string;
+    /**
+     * Sets the dialog title icon
+     */
+    titleLeftIcon?: ReactNode;
+    /**
+     * Utilized to run extra callbacks on dialog-close
+     */
+    onDialogClose?: any;
+    /**
+     * If set to true, the close-button will not be visible
+     */
+    hideOnClose?: boolean;
+}
+
+export type CompactDialogRef = {
+    /**
+     * Opens the dialog
+     */
+    open: () => void;
+    /**
+     * Closes the dialog and calls `onDialogClose` if set
+     */
+    close: () => void;
+    /**
+     * Activates Close-Button if disabled
+     */
+    activateOnClose: () => void;
+    /**
+     * Disables Close-Button if enabled
+     */
+    disableOnClose: () => void;
+} | null;
+
+export const CompactDialog = forwardRef<CompactDialogRef, CompactDialogProps>((props, ref) => {
+    const { title, titleLeftIcon, onDialogClose, hideOnClose, children } = props;
+
+    const [isOpen, setIsOpen] = useState<boolean>(false);
+    const [isCloseDisabled, setIsCloseDisabled] = useState<boolean>(false);
+
+    useImperativeHandle(ref, () => ({
+        open: () => {
+            setIsOpen(true);
+        },
+        close: () => {
+            setIsOpen(false);
+            if (onDialogClose) onDialogClose();
+        },
+        activateOnClose: () => {
+            setIsCloseDisabled(true);
+        },
+        disableOnClose: () => {
+            setIsCloseDisabled(true);
+        },
+    }));
+
+    const onClose = useCallback(() => {
+        setIsOpen(false);
+        if (onDialogClose) onDialogClose();
+    }, [onDialogClose]);
+
+    return (
+        <Scrim open={isOpen} onClose={() => setIsOpen(false)}>
+            <CompactDialogCard
+                title={title}
+                titleLeftIcon={titleLeftIcon}
+                onClose={onClose}
+                disableOnClose={isCloseDisabled}
+                hideOnClose={hideOnClose}
+            >
+                {children}
+            </CompactDialogCard>
+        </Scrim>
+    );
+});

--- a/src/components/CompactDialog/CompactDialog.tsx
+++ b/src/components/CompactDialog/CompactDialog.tsx
@@ -15,7 +15,7 @@ export interface CompactDialogProps {
     /**
      * If set to true, the close-button will not be visible
      */
-    hideOnClose?: boolean;
+    hideCloseButton?: boolean;
 }
 
 export type CompactDialogRef = {
@@ -38,7 +38,7 @@ export type CompactDialogRef = {
 } | null;
 
 export const CompactDialog = forwardRef<CompactDialogRef, CompactDialogProps>((props, ref) => {
-    const { title, titleLeftIcon, hideOnClose, children } = props;
+    const { title, titleLeftIcon, hideCloseButton, children } = props;
 
     const [isOpen, setIsOpen] = useState<boolean>(false);
     const [isCloseDisabled, setIsCloseDisabled] = useState<boolean>(false);
@@ -65,7 +65,7 @@ export const CompactDialog = forwardRef<CompactDialogRef, CompactDialogProps>((p
                 titleLeftIcon={titleLeftIcon}
                 onClose={() => setIsOpen(false)}
                 disableOnClose={isCloseDisabled}
-                hideOnClose={hideOnClose}
+                hideCloseButton={hideCloseButton}
             >
                 {children}
             </CompactDialogCard>

--- a/src/components/CompactDialog/CompactDialog.tsx
+++ b/src/components/CompactDialog/CompactDialog.tsx
@@ -3,7 +3,7 @@ import React, { forwardRef, ReactNode, useImperativeHandle, useState } from 'rea
 import CompactDialogCard from './CompactDialogCard';
 
 export interface CompactDialogProps {
-    children?: React.ReactNode | null;
+    children?: React.ReactNode;
     /**
      * Sets the dialog title
      */

--- a/src/components/CompactDialog/CompactDialog.tsx
+++ b/src/components/CompactDialog/CompactDialog.tsx
@@ -1,5 +1,5 @@
 import { Scrim } from '@equinor/eds-core-react';
-import React, { forwardRef, ReactNode, useCallback, useImperativeHandle, useState } from 'react';
+import React, { forwardRef, ReactNode, useImperativeHandle, useState } from 'react';
 import CompactDialogCard from './CompactDialogCard';
 
 export interface CompactDialogProps {
@@ -12,10 +12,6 @@ export interface CompactDialogProps {
      * Sets the dialog title icon
      */
     titleLeftIcon?: ReactNode;
-    /**
-     * Utilized to run extra callbacks on dialog-close
-     */
-    onDialogClose?: any;
     /**
      * If set to true, the close-button will not be visible
      */
@@ -42,7 +38,7 @@ export type CompactDialogRef = {
 } | null;
 
 export const CompactDialog = forwardRef<CompactDialogRef, CompactDialogProps>((props, ref) => {
-    const { title, titleLeftIcon, onDialogClose, hideOnClose, children } = props;
+    const { title, titleLeftIcon, hideOnClose, children } = props;
 
     const [isOpen, setIsOpen] = useState<boolean>(false);
     const [isCloseDisabled, setIsCloseDisabled] = useState<boolean>(false);
@@ -53,7 +49,6 @@ export const CompactDialog = forwardRef<CompactDialogRef, CompactDialogProps>((p
         },
         close: () => {
             setIsOpen(false);
-            if (onDialogClose) onDialogClose();
         },
         activateOnClose: () => {
             setIsCloseDisabled(true);
@@ -63,17 +58,12 @@ export const CompactDialog = forwardRef<CompactDialogRef, CompactDialogProps>((p
         },
     }));
 
-    const onClose = useCallback(() => {
-        setIsOpen(false);
-        if (onDialogClose) onDialogClose();
-    }, [onDialogClose]);
-
     return (
-        <Scrim open={isOpen} onClose={() => setIsOpen(false)}>
+        <Scrim open={isOpen}>
             <CompactDialogCard
                 title={title}
                 titleLeftIcon={titleLeftIcon}
-                onClose={onClose}
+                onClose={() => setIsOpen(false)}
                 disableOnClose={isCloseDisabled}
                 hideOnClose={hideOnClose}
             >

--- a/src/components/CompactDialog/CompactDialogAction.tsx
+++ b/src/components/CompactDialog/CompactDialogAction.tsx
@@ -1,0 +1,13 @@
+import React, { FC } from 'react';
+import styled from 'styled-components';
+
+const Wrapper = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 1em;
+`;
+
+export const CompactDialogAction: FC = ({ children }) => {
+    return <Wrapper>{children}</Wrapper>;
+};

--- a/src/components/CompactDialog/CompactDialogCard.tsx
+++ b/src/components/CompactDialog/CompactDialogCard.tsx
@@ -36,10 +36,10 @@ interface Props {
     titleLeftIcon?: ReactNode;
     onClose: () => void;
     disableOnClose?: boolean;
-    hideOnClose?: boolean;
+    hideCloseButton?: boolean;
 }
 
-const CompactDialogCard: FC<Props> = ({ title, titleLeftIcon, onClose, disableOnClose, hideOnClose, children }) => (
+const CompactDialogCard: FC<Props> = ({ title, titleLeftIcon, onClose, disableOnClose, hideCloseButton, children }) => (
     <ScrimOuterWrapper>
         <EdsProvider density="compact">
             <ScrimTitleWrapper>
@@ -49,7 +49,9 @@ const CompactDialogCard: FC<Props> = ({ title, titleLeftIcon, onClose, disableOn
                         <Typography variant="h6">{title}</Typography>
                     </ScrimTitleLeftWrapper>
                 )}
-                {!hideOnClose && (
+                {hideCloseButton ? (
+                    <></>
+                ) : (
                     <Button variant="ghost_icon" onClick={onClose} disabled={disableOnClose}>
                         <Icon data={icons.close} />
                     </Button>

--- a/src/components/CompactDialog/CompactDialogCard.tsx
+++ b/src/components/CompactDialog/CompactDialogCard.tsx
@@ -1,0 +1,64 @@
+import React, { FC, ReactNode } from 'react';
+import styled from 'styled-components';
+
+import { Button, EdsProvider, Icon, Typography } from '@equinor/eds-core-react';
+
+import { icons } from 'components/icons';
+
+const ScrimOuterWrapper = styled.div`
+    min-width: 20em;
+    min-height: 10em;
+    background: #ffffff;
+    border-radius: 0.3rem;
+    box-shadow: 0 3px 30px #383838;
+`;
+const ScrimTitleWrapper = styled.div`
+    padding: 0.8rem 1rem 0.5rem 1rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+`;
+const ScrimTitleLeftWrapper = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+`;
+const ScrimContent = styled.div`
+    padding: 1rem;
+`;
+const HorizontalDivider = styled.div`
+    border-top: 0.1px solid #dfdfdf;
+    margin: 0;
+`;
+
+interface Props {
+    title?: string;
+    titleLeftIcon?: ReactNode;
+    onClose: () => void;
+    disableOnClose?: boolean;
+    hideOnClose?: boolean;
+}
+
+const CompactDialogCard: FC<Props> = ({ title, titleLeftIcon, onClose, disableOnClose, hideOnClose, children }) => (
+    <ScrimOuterWrapper>
+        <EdsProvider density="compact">
+            <ScrimTitleWrapper>
+                {(titleLeftIcon || title) && (
+                    <ScrimTitleLeftWrapper>
+                        {titleLeftIcon}
+                        <Typography variant="h6">{title}</Typography>
+                    </ScrimTitleLeftWrapper>
+                )}
+                {!hideOnClose && (
+                    <Button variant="ghost_icon" onClick={onClose} disabled={disableOnClose}>
+                        <Icon data={icons.close} />
+                    </Button>
+                )}
+            </ScrimTitleWrapper>
+        </EdsProvider>
+        <HorizontalDivider />
+        <ScrimContent>{children}</ScrimContent>
+    </ScrimOuterWrapper>
+);
+
+export default CompactDialogCard;

--- a/src/components/CompactDialog/index.tsx
+++ b/src/components/CompactDialog/index.tsx
@@ -1,0 +1,17 @@
+import { CompactDialog as CompactDialogBase, CompactDialogProps, CompactDialogRef } from './CompactDialog';
+import { CompactDialogAction } from './CompactDialogAction';
+
+type CompactDialogCompound = typeof CompactDialogBase & {
+    Actions: typeof CompactDialogAction;
+};
+
+const CompactDialog = CompactDialogBase as CompactDialogCompound;
+
+CompactDialog.Actions = CompactDialogAction;
+
+CompactDialog.Actions.displayName = 'CompactDialog.Actions';
+
+export { CompactDialog };
+
+// export Props and Types
+export { CompactDialogProps, CompactDialogRef };

--- a/src/components/DataTable/plugins/ColumnSelector/ColumnSelectorDialog.tsx
+++ b/src/components/DataTable/plugins/ColumnSelector/ColumnSelectorDialog.tsx
@@ -1,0 +1,91 @@
+import { Checkbox, Density, EdsProvider, Typography } from '@equinor/eds-core-react';
+import React, { FC } from 'react';
+import styled from 'styled-components';
+
+const GroupsWrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 1em;
+`;
+interface OptionsWrapperProps {
+    columnsNumber?: number;
+    rowsNumber?: number;
+}
+const OptionsGroupWrapper = styled.div<OptionsWrapperProps>`
+    display: grid;
+    grid-template-columns: ${({ columnsNumber }) =>
+        columnsNumber ? `repeat(${columnsNumber}, auto)` : 'repeat(2, auto)'};
+    grid-template-rows: ${({ rowsNumber }) => (rowsNumber ? `repeat(${rowsNumber}, auto)` : 'repeat(5, auto)')};
+    grid-auto-flow: row;
+    margin-top: 0.3rem;
+`;
+
+const CheckBoxWrapper = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+`;
+
+const CheckBoxLabel = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    padding: 0.2em;
+    pointer-events: none;
+    cursor: default;
+`;
+
+interface Props {
+    density?: Density;
+    columnsNumber?: number;
+    rowsNumber?: number;
+    visibleColumns?: any;
+    onCheck: (column: JSX.Element | string) => void;
+
+    columns: any;
+}
+
+const ColumnSelectorDialog: FC<Props> = ({ density, columnsNumber, rowsNumber, visibleColumns, columns, onCheck }) => {
+    return (
+        <>
+            <GroupsWrapper>
+                <EdsProvider density={density}>
+                    <span>
+                        <Typography variant="h6">Default columns</Typography>
+                        <OptionsGroupWrapper columnsNumber={columnsNumber} rowsNumber={rowsNumber}>
+                            {columns
+                                .filter((x: any) => !x.props.optional && !x.props.id.startsWith('__'))
+                                .map((column: any) => (
+                                    <CheckBoxWrapper key={column.props.id}>
+                                        <Checkbox
+                                            checked={visibleColumns?.includes(column.props.id)}
+                                            onChange={() => onCheck(column)}
+                                        />
+                                        <CheckBoxLabel>{column.props.children}</CheckBoxLabel>
+                                    </CheckBoxWrapper>
+                                ))}
+                        </OptionsGroupWrapper>
+                    </span>
+                    <span>
+                        <Typography variant="h6">Optional columns</Typography>
+                        <OptionsGroupWrapper columnsNumber={columnsNumber} rowsNumber={rowsNumber}>
+                            {columns
+                                .filter((x: any) => x.props.optional && !x.props.id.startsWith('__'))
+                                .map((column: any) => (
+                                    <CheckBoxWrapper key={column.props.id}>
+                                        <Checkbox
+                                            checked={visibleColumns?.includes(column.props.id)}
+                                            onChange={() => onCheck(column)}
+                                        />
+                                        <CheckBoxLabel>{column.props.children}</CheckBoxLabel>
+                                    </CheckBoxWrapper>
+                                ))}
+                        </OptionsGroupWrapper>
+                    </span>
+                </EdsProvider>
+            </GroupsWrapper>
+        </>
+    );
+};
+
+export default ColumnSelectorDialog;

--- a/src/components/DataTable/plugins/ColumnSelector/index.tsx
+++ b/src/components/DataTable/plugins/ColumnSelector/index.tsx
@@ -61,7 +61,7 @@ export type ColumnSelectorProps = {
      */
     showApplyButton?: boolean;
     /**
-     * Utilized to change the style of the columns options
+     * Utilized to change the style of the Dialog
      */
     dialogStyle?: DialogStyle;
 };

--- a/src/components/DataTable/plugins/ColumnSelector/index.tsx
+++ b/src/components/DataTable/plugins/ColumnSelector/index.tsx
@@ -2,7 +2,7 @@ import React, { Ref } from 'react';
 
 import { Density } from '@equinor/eds-core-react';
 
-import { FC, ReducerProp } from '../../types';
+import { ReducerProp } from '../../types';
 import { columnSelectorReducer } from './columnSelectorReducer';
 
 export type ColumnSelectorRef = {
@@ -57,9 +57,13 @@ export type ColumnSelectorProps = {
      */
     storage?: Storage;
     /**
+     * If set, it will show an Apply button
+     */
+    showApplyButton?: boolean;
+    /**
      * Utilized to change the style of the columns options
      */
-    optionsStyle?: DialogStyle;
+    dialogStyle?: DialogStyle;
 };
 
 const ColumnSelector: React.FC<ColumnSelectorProps> & ReducerProp = (props) => {

--- a/src/components/DataTable/plugins/ColumnSelector/index.tsx
+++ b/src/components/DataTable/plugins/ColumnSelector/index.tsx
@@ -57,11 +57,11 @@ export type ColumnSelectorProps = {
      */
     storage?: Storage;
     /**
-     * If set, it will show an Apply button
+     * If set, it will show an Apply button; defaults to "false"
      */
     showApplyButton?: boolean;
     /**
-     * Utilized to change the style of the Dialog
+     * Utilized to change the style of the `Dialog`
      */
     dialogStyle?: DialogStyle;
 };

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -69,7 +69,7 @@ import {
     warning_outlined,
 } from '@equinor/eds-icons';
 
-const icons = {
+export const icons = {
     accessible,
     account_circle,
     add,
@@ -136,8 +136,8 @@ const icons = {
     visibility,
     visibility_off,
     warning_outlined,
-}
+};
 
 export const addIcons = () => {
     Icon.add(icons);
-}
+};


### PR DESCRIPTION
## Changes: 

- feat: add CompactDialog component (less feature-rich than `Dialog`, and more compact)

### Breaking changes
-feat!: rename `ColumnSelector`'s optionsStyle to dialogStyle, as it now also decides what Dialog to use.
-feat!: make   `ColumnSelector`'s label not clickable. This caused interactable lablels to be clickable from the dialog
-feat! make apply-button invisible by default. Can appear again by using the prop "showApplyButton"


### E.g. compact dialog: 
![image](https://user-images.githubusercontent.com/54411648/177545934-5929e0d5-ecb1-4012-8c00-c00ce1c88656.png)

### E.g. normal dialog
![image](https://user-images.githubusercontent.com/54411648/177546484-27f760c2-670f-48a4-bf2f-39018ccb4910.png)
